### PR TITLE
fixed error when computer is about to lose

### DIFF
--- a/src/ch/ksobwalden/ef4win/ConnectFourLib.java
+++ b/src/ch/ksobwalden/ef4win/ConnectFourLib.java
@@ -282,7 +282,7 @@ public class ConnectFourLib {
 	public static int computerProfiSpielzug(int spieler, int[][] spielfeld){
 		checkValidSpielfeldOrThrow(spielfeld);
 		checkValidSpielerOrThrow(spieler);
-		long maxval = Integer.MIN_VALUE;
+		long maxval = Long.MIN_VALUE;
 		List<Integer> maxcols = new ArrayList<>();
 		int[][] spielfeldCopy = new int[SPIELFELD_HOEHE][SPIELFELD_BREITE];
 		arraycopy(spielfeld, spielfeldCopy);


### PR DESCRIPTION
If the computer can't win, an indexoutofboundsexception occurs, because he has no possible moves left.